### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Build C Project
+permissions:
+  contents: read
 
 on:
   push:
@@ -8,6 +10,9 @@ on:
 
 jobs:
   headergrab:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/octopusnz/aoc-2020/security/code-scanning/1](https://github.com/octopusnz/aoc-2020/security/code-scanning/1)

To fix the problem, add a `permissions` block at the top level of the workflow to set the default to `contents: read`, which is the minimal permission required for most jobs. Then, for the `headergrab` job, add a `permissions` block granting the least privilege necessary for its actions. Since `headergrab` pushes commits and creates pull requests, it needs `contents: write` and `pull-requests: write`. The `build` job does not need any write permissions, so it will inherit the default `contents: read`.  
**Steps:**  
- Insert a `permissions:` block after the workflow `name:` and before `on:`, setting `contents: read`.
- Add a `permissions:` block under the `headergrab:` job, setting `contents: write` and `pull-requests: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
